### PR TITLE
Update stats url

### DIFF
--- a/e2e/support/pages/StatsPage.ts
+++ b/e2e/support/pages/StatsPage.ts
@@ -4,11 +4,15 @@ import { Page } from '@playwright/test';
  * Page object for the Stats page (/stats).
  */
 export class StatsPage {
-  constructor(private page: Page) {}
+  private readonly url: string;
+
+  constructor(private page: Page) {
+    this.url = (process.env.E2E_BASE_URL || 'http://localhost:5173') + '/stats';
+  }
 
   /** Navigate directly to the stats page via URL. */
   async goto(): Promise<void> {
-    await this.page.goto('/stats');
+    await this.page.goto(this.url);
   }
 
   /** True if the stats data grid is visible (i.e. there is session data). */


### PR DESCRIPTION
so the tests run agains the base url during e2e (localhost or the just deployed one)