### PR TITLE
More improvements

### DIFF
--- a/e2e/tests/tournament-elimination.spec.ts
+++ b/e2e/tests/tournament-elimination.spec.ts
@@ -32,10 +32,10 @@ test.describe('Tournament Page - Elimination', () => {
       await expect(page.locator('[data-testid="bracket-node-tbd"]').first()).toBeVisible();
     });
 
-    await expect(page.getByTestId('bracket-round-label-Semi-Final')).toBeVisible();
+    await expect(page.getByTestId('wb-section').getByTestId('bracket-round-label-Semi-Final')).toBeVisible();
     await expect(page.getByTestId('wb-section')).toBeVisible();
 
-    await expect(page.getByTestId('cb-section')).not.toBeVisible();
+    await expect(page.getByTestId('cb-section')).toBeVisible();
 
     const wbR1Teams = await page.locator('[data-testid^="bracket-team-1-"]').all();
     expect(wbR1Teams.length).toBeGreaterThanOrEqual(2);
@@ -62,7 +62,7 @@ test.describe('Tournament Page - Elimination', () => {
       await expect(page.locator('[data-testid="bracket-node-bye"]').first()).toBeVisible();
     });
 
-    await expect(page.getByTestId('cb-section')).not.toBeVisible();
+    await expect(page.getByTestId('cb-section')).toBeVisible();
 
     const wbSection = page.getByTestId('wb-section');
     let wbFinalLoserName: string;
@@ -116,8 +116,9 @@ test.describe('Tournament Page - Elimination', () => {
     await tournamentPage.selectType('elimination');
     await tournamentPage.startElimination();
 
-    await expect(page.getByTestId('bracket-round-label-4th-of-Final')).toBeVisible();
-    await expect(page.getByTestId('bracket-round-label-Semi-Final')).toBeVisible();
+    const wbSection = page.getByTestId('wb-section');
+    await expect(wbSection.getByTestId('bracket-round-label-4th-of-Final')).toBeVisible();
+    await expect(wbSection.getByTestId('bracket-round-label-Semi-Final')).toBeVisible();
   });
 
   test('elimination tournament state persists across reload', async ({ page }) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,6 @@ import { CourtAssignments } from './components/court';
 import { useShareState } from './hooks/useShareState';
 import Leaderboard from './components/players/Leaderboard';
 import Footer from './components/Footer';
-import { storageManager } from './utils/StorageManager';
 import { useAppState } from './providers/AppStateProvider';
 import { benchedPlayers } from './utils/playerUtils';
 import type { Court, ManualCourtSelection, WinnerSelection } from './types';
@@ -18,25 +17,33 @@ export function rotateCourtTeams(court: Court): Court {
   const { teams, players } = court;
   if (!teams) return court;
 
+  const cleared = { ...court, winner: undefined, score: undefined };
+
   if (players.length === 4) {
     const [p0, p1, p2, p3] = players;
     const team1Ids = new Set(teams.team1.map(p => p.id));
 
     if (team1Ids.has(p0.id) && team1Ids.has(p1.id)) {
-      return { ...court, teams: { team1: [p0, p2], team2: [p1, p3] }, winner: undefined };
+      return { ...cleared, teams: { team1: [p0, p2], team2: [p1, p3] } };
     } else if (team1Ids.has(p0.id) && team1Ids.has(p2.id)) {
-      return { ...court, teams: { team1: [p0, p3], team2: [p1, p2] }, winner: undefined };
+      return { ...cleared, teams: { team1: [p0, p3], team2: [p1, p2] } };
     } else {
-      return { ...court, teams: { team1: [p0, p1], team2: [p2, p3] }, winner: undefined };
+      return { ...cleared, teams: { team1: [p0, p1], team2: [p2, p3] } };
     }
   }
 
-  return { ...court, teams: { team1: teams.team2, team2: teams.team1 }, winner: undefined };
+  return { ...cleared, teams: { team1: teams.team2, team2: teams.team1 } };
 }
 
 function App(): React.ReactElement {
   const {
     players,
+    numberOfCourts,
+    setNumberOfCourts,
+    assignments,
+    setAssignments,
+    lastGeneratedAt,
+    setLastGeneratedAt,
     isLoaded,
     handlePlayerToggle,
     handleAddPlayers,
@@ -50,41 +57,23 @@ function App(): React.ReactElement {
     benchCounts,
     generate,
     updateWinner,
-    saveState,
     resetAlgorithm,
   } = useAppState();
 
-  const [numberOfCourts, setNumberOfCourts] = useState<number>(4);
-  const [assignments, setAssignments] = useState<Court[]>([]);
   const [isManagePlayersCollapsed, setIsManagePlayersCollapsed] = useState<boolean>(false);
   const [manualCourtSelection, setManualCourtSelection] = useState<ManualCourtSelection | null>(null);
-  const [lastGeneratedAt, setLastGeneratedAt] = useState<number | undefined>();
   const [forceBenchPlayerIds, setForceBenchPlayerIds] = useState<Set<string>>(new Set());
 
   const { shareUrl, setShareUrl, importState, handleShare, handleImportAccept, handleImportDecline } = useShareState();
 
-  const hasLocalLoadedRef = useRef(false);
+  const hasInitialisedCollapseRef = useRef(false);
   const managePlayersRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    const load = async () => {
-      const loadedState = await storageManager.loadApp();
-      if (loadedState.players?.length) {
-        setIsManagePlayersCollapsed(true);
-      }
-      if (loadedState.numberOfCourts !== undefined) setNumberOfCourts(loadedState.numberOfCourts);
-      if (loadedState.assignments?.length) setAssignments(loadedState.assignments);
-      if (loadedState.lastGeneratedAt !== undefined) setLastGeneratedAt(loadedState.lastGeneratedAt);
-      hasLocalLoadedRef.current = true;
-    };
-    load();
-  }, []);
-
-  useEffect(() => {
-    if (!hasLocalLoadedRef.current) return;
-    storageManager.saveApp({ numberOfCourts, assignments, lastGeneratedAt });
-    void saveState();
-  }, [numberOfCourts, assignments, lastGeneratedAt]);
+    if (!isLoaded || hasInitialisedCollapseRef.current) return;
+    hasInitialisedCollapseRef.current = true;
+    if (players.length > 0) setIsManagePlayersCollapsed(true);
+  }, [isLoaded, players]);
 
   const handleClearAllPlayers = () => {
     clearPlayers();
@@ -154,10 +143,9 @@ function App(): React.ReactElement {
 
   const handleViewBenchCounts = () => {
     setIsManagePlayersCollapsed(false);
-    const timerId = setTimeout(() => {
+    setTimeout(() => {
       managePlayersRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
     }, 100);
-    return () => clearTimeout(timerId);
   };
 
   const toggleManagePlayers = (event?: React.MouseEvent) => {
@@ -176,7 +164,6 @@ function App(): React.ReactElement {
       <div className="container main-container">
         <h1><span className="title-emoji">🏸 </span>Badminton Court Manager</h1>
 
-        {/* Manage Players Section - Collapsible */}
         <div
           ref={managePlayersRef}
           className={`section ${isManagePlayersCollapsed ? 'collapsed' : ''}`}
@@ -214,7 +201,6 @@ function App(): React.ReactElement {
           )}
         </div>
 
-        {/* Court Assignments Section - Never collapsed */}
         <div className="section" data-testid="court-assignments-section">
           <div className="section-header no-collapse">
             <h2>Court Assignments</h2>
@@ -232,7 +218,7 @@ function App(): React.ReactElement {
               onScoreChange={handleScoreChange}
               hasHistoricalWinners={winCounts.size > 0}
               onRotateTeams={handleRotateTeams}
-              hasManualCourtSelection={assignments.some(court => (court as any).wasManuallyAssigned)}
+              hasManualCourtSelection={assignments.some(court => court.wasManuallyAssigned)}
               onViewBenchCounts={handleViewBenchCounts}
               manualCourtSelection={manualCourtSelection}
               onManualCourtSelectionChange={setManualCourtSelection}

--- a/src/components/court/CourtAssignments.tsx
+++ b/src/components/court/CourtAssignments.tsx
@@ -161,7 +161,7 @@ const CourtAssignments: React.FC<CourtAssignmentsProps> = ({
         <>
           <div className="courts-grid">
             {assignments.map((court) => {
-              const isManualCourt = (court as any).wasManuallyAssigned || (hasManualCourtSelection && court.courtNumber === 1);
+              const isManualCourt = court.wasManuallyAssigned || (hasManualCourtSelection && court.courtNumber === 1);
               return (
                 <CourtCard
                   key={court.courtNumber}

--- a/src/components/modals/ImageUploadModal.tsx
+++ b/src/components/modals/ImageUploadModal.tsx
@@ -97,6 +97,15 @@ const ImageUploadModal: React.FC<ImageUploadModalProps> = ({
       className="image-upload-modal"
     >
       <div className="modal-body">
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/*"
+          capture="environment"
+          onChange={handleFileSelect}
+          className="file-input"
+          data-testid="image-file-input"
+        />
         {extractedPlayers.length === 0 ? (
           <>
             <div
@@ -117,15 +126,6 @@ const ImageUploadModal: React.FC<ImageUploadModalProps> = ({
                   Choose Image
                 </button>
               </div>
-              <input
-                ref={fileInputRef}
-                type="file"
-                accept="image/*"
-                capture="environment"
-                onChange={handleFileSelect}
-                className="file-input"
-                data-testid="image-file-input"
-              />
             </div>
 
             {isProcessing && (

--- a/src/components/modals/ScoreInputModal.tsx
+++ b/src/components/modals/ScoreInputModal.tsx
@@ -47,14 +47,17 @@ const ScoreInputModal: React.FC<ScoreInputModalProps> = ({
     }
   };
 
+  const defaults = winnerTeam === 1 ? { team1: 21, team2: 18 } : { team1: 18, team2: 21 };
+
+  const parsed1 = parseInt(score1, 10);
+  const parsed2 = parseInt(score2, 10);
+  const resolvedScore = {
+    team1: isNaN(parsed1) ? defaults.team1 : parsed1,
+    team2: isNaN(parsed2) ? defaults.team2 : parsed2,
+  };
+
   const handleConfirm = () => {
-    const parsed1 = parseInt(score1, 10);
-    const parsed2 = parseInt(score2, 10);
-    const default1 = winnerTeam === 2 ? 18 : 21;
-    const default2 = winnerTeam === 1 ? 18 : 21;
-    const team1Score = isNaN(parsed1) ? default1 : parsed1;
-    const team2Score = isNaN(parsed2) ? default2 : parsed2;
-    onConfirm({ team1: team1Score, team2: team2Score });
+    onConfirm(resolvedScore);
     setScore1('');
     setScore2('');
   };
@@ -65,13 +68,9 @@ const ScoreInputModal: React.FC<ScoreInputModalProps> = ({
     onCancel();
   };
 
-  const n1 = parseInt(score1, 10);
-  const n2 = parseInt(score2, 10);
-  const effDefault1 = winnerTeam === 2 ? 18 : 21;
-  const effDefault2 = winnerTeam === 1 ? 18 : 21;
-  const eff1 = isNaN(n1) ? effDefault1 : n1;
-  const eff2 = isNaN(n2) ? effDefault2 : n2;
-  const isConfirmDisabled = (winnerTeam === 1 && eff1 < eff2) || (winnerTeam === 2 && eff2 < eff1);
+  const isConfirmDisabled =
+    (winnerTeam === 1 && resolvedScore.team1 < resolvedScore.team2) ||
+    (winnerTeam === 2 && resolvedScore.team2 < resolvedScore.team1);
 
   const teamNames = (players: Player[]) => players.map(p => p.name).join(' & ');
 
@@ -83,7 +82,7 @@ const ScoreInputModal: React.FC<ScoreInputModalProps> = ({
       testId="score-input-modal"
     >
       <div className="modal-body">
-        <p>Optionally enter the score:</p>
+        <p>Enter the score (defaults to 21 – 18):</p>
         <div className="score-modal-teams">
           <span className="score-modal-team-name">{teamNames(team1Players)}</span>
           <span className="score-modal-vs">vs</span>
@@ -95,7 +94,7 @@ const ScoreInputModal: React.FC<ScoreInputModalProps> = ({
             min="0"
             value={score1}
             onChange={(e) => handleScore1Change(e.target.value)}
-            placeholder={winnerTeam === 2 ? '18' : '21'}
+            placeholder={String(defaults.team1)}
             aria-label="Team 1 score"
             data-testid="score-input-team1"
           />
@@ -105,7 +104,7 @@ const ScoreInputModal: React.FC<ScoreInputModalProps> = ({
             min="0"
             value={score2}
             onChange={(e) => handleScore2Change(e.target.value)}
-            placeholder={winnerTeam === 1 ? '18' : '21'}
+            placeholder={String(defaults.team2)}
             aria-label="Team 2 score"
             data-testid="score-input-team2"
           />

--- a/src/components/tournament/round-robin/RoundRobinMatches.tsx
+++ b/src/components/tournament/round-robin/RoundRobinMatches.tsx
@@ -75,7 +75,7 @@ export const RoundRobinMatches: React.FC<RoundRobinMatchesProps> = ({
     <div className="tournament-matches" data-testid="tournament-matches">
       {roundNums.map(round => {
         const roundMatches = tournament.matchesForRound(round);
-        const isExpanded = expandedRounds.has(round) || (!allComplete && round === currentRound);
+        const isExpanded = expandedRounds.has(round);
         const roundDone = tournament.isRoundComplete(round);
 
         return (

--- a/src/engines/BaseCourtAssignmentEngine.ts
+++ b/src/engines/BaseCourtAssignmentEngine.ts
@@ -73,7 +73,7 @@ export abstract class BaseCourtAssignmentEngine extends CourtAssignmentTracker i
 
     if (!replaceRound) this.markRoundCompleted();
     this.clearCurrentSession();
-    this.lastGeneratedAt = Date.now();
+    CourtAssignmentTracker.lastGeneratedAt = Date.now();
     if (replaceRound) this.undoLastRound();
     const detectedAnomalies = this.applyRoundStats(finalCourts, presentPlayers);
     const anomalies = replaceRound ? [] : detectedAnomalies;

--- a/src/engines/CourtAssignmentTracker.ts
+++ b/src/engines/CourtAssignmentTracker.ts
@@ -68,13 +68,13 @@ export class CourtAssignmentTracker implements ICourtAssignmentTracker {
   static readonly REGENERATION_DEBOUNCE_MS = 2 * 60 * 1000;
 
   /** Court numbers whose team-pair stats were already updated via rotation this round */
-  private pendingRotatedCourts = new Set<number>();
+  private static pendingRotatedCourts = new Set<number>();
 
   /** Delta of stats recorded in the most recent generate() call, used to undo on replace */
-  private lastRoundDelta: { bench: string[]; singles: string[]; teammates: string[]; opponents: string[] } | null = null;
+  private static lastRoundDelta: { bench: string[]; singles: string[]; teammates: string[]; opponents: string[] } | null = null;
 
   /** Timestamp of the most recent generate() call, used to detect rapid regeneration */
-  protected lastGeneratedAt: number | undefined = undefined;
+  protected static lastGeneratedAt: number | undefined = undefined;
 
   protected get teammateCountMap(): Map<string, number> {
     return CourtAssignmentTracker.teammateCountMap;
@@ -122,8 +122,8 @@ export class CourtAssignmentTracker implements ICourtAssignmentTracker {
     CourtAssignmentTracker.levelHistoryMap.clear();
     CourtAssignmentTracker.globalCounter = 0;
     CourtAssignmentTracker.roundsPlayed = 0;
-    this.lastRoundDelta = null;
-    this.lastGeneratedAt = undefined;
+    CourtAssignmentTracker.lastRoundDelta = null;
+    CourtAssignmentTracker.lastGeneratedAt = undefined;
     this.notifyStateChange();
   }
 
@@ -141,8 +141,8 @@ export class CourtAssignmentTracker implements ICourtAssignmentTracker {
    */
   protected shouldCommitRound(): boolean {
     const isRapidRegeneration =
-      this.lastGeneratedAt !== undefined &&
-      Date.now() - this.lastGeneratedAt < CourtAssignmentTracker.REGENERATION_DEBOUNCE_MS;
+      CourtAssignmentTracker.lastGeneratedAt !== undefined &&
+      Date.now() - CourtAssignmentTracker.lastGeneratedAt < CourtAssignmentTracker.REGENERATION_DEBOUNCE_MS;
     const hasWinners = CourtAssignmentTracker.recordedWinsMap.size > 0;
     return !isRapidRegeneration || hasWinners;
   }
@@ -153,14 +153,25 @@ export class CourtAssignmentTracker implements ICourtAssignmentTracker {
     CourtAssignmentTracker.lossCountMap.delete(playerId);
     CourtAssignmentTracker.benchCountMap.delete(playerId);
     CourtAssignmentTracker.singleCountMap.delete(playerId);
+    CourtAssignmentTracker.levelHistoryMap.delete(playerId);
+    const pairMaps = [
+      CourtAssignmentTracker.teammateCountMap,
+      CourtAssignmentTracker.opponentCountMap,
+      CourtAssignmentTracker.lastUpdatedMap,
+    ];
+    for (const map of pairMaps) {
+      for (const key of [...map.keys()]) {
+        if (key.split('|').includes(playerId)) map.delete(key);
+      }
+    }
     this.notifyStateChange();
   }
 
   /** Clears only the current session's recorded match outcomes. */
   clearCurrentSession(): void {
     CourtAssignmentTracker.recordedWinsMap.clear();
-    this.pendingRotatedCourts.clear();
-    this.lastGeneratedAt = undefined;
+    CourtAssignmentTracker.pendingRotatedCourts.clear();
+    CourtAssignmentTracker.lastGeneratedAt = undefined;
   }
 
   /**
@@ -170,7 +181,7 @@ export class CourtAssignmentTracker implements ICourtAssignmentTracker {
    * Returns anomalies detected by comparing against the previous round's delta.
    */
   applyRoundStats(courts: Court[], players: Player[]): AssignmentAnomaly[] {
-    const prev = this.lastRoundDelta;
+    const prev = CourtAssignmentTracker.lastRoundDelta;
     const delta = { bench: [] as string[], singles: [] as string[], teammates: [] as string[], opponents: [] as string[] };
 
     benchedPlayers(courts, players).forEach(p => {
@@ -188,7 +199,7 @@ export class CourtAssignmentTracker implements ICourtAssignmentTracker {
         });
       }
 
-      if (!this.pendingRotatedCourts.has(court.courtNumber)) {
+      if (!CourtAssignmentTracker.pendingRotatedCourts.has(court.courtNumber)) {
         this.updateCourtTeamStats(court);
         const { team1, team2 } = court.teams;
         for (const team of [team1, team2]) {
@@ -198,7 +209,7 @@ export class CourtAssignmentTracker implements ICourtAssignmentTracker {
       }
     });
 
-    this.lastRoundDelta = delta;
+    CourtAssignmentTracker.lastRoundDelta = delta;
     return this.detectAnomalies(prev, delta);
   }
 
@@ -236,13 +247,13 @@ export class CourtAssignmentTracker implements ICourtAssignmentTracker {
 
   /** Reverses the stats recorded by the most recent applyRoundStats call. */
   protected undoLastRound(): void {
-    if (!this.lastRoundDelta) return;
-    const { bench, singles, teammates, opponents } = this.lastRoundDelta;
+    if (!CourtAssignmentTracker.lastRoundDelta) return;
+    const { bench, singles, teammates, opponents } = CourtAssignmentTracker.lastRoundDelta;
     bench.forEach(id => this.decrementMapCount(CourtAssignmentTracker.benchCountMap, id));
     singles.forEach(id => this.decrementMapCount(CourtAssignmentTracker.singleCountMap, id));
     teammates.forEach(key => this.decrementMapCount(CourtAssignmentTracker.teammateCountMap, key));
     opponents.forEach(key => this.decrementMapCount(CourtAssignmentTracker.opponentCountMap, key));
-    this.lastRoundDelta = null;
+    CourtAssignmentTracker.lastRoundDelta = null;
   }
 
   /** Prepares the internal maps for persistence. Filters and prunes old data. */
@@ -447,7 +458,7 @@ export class CourtAssignmentTracker implements ICourtAssignmentTracker {
     }
 
     if (rotatedCourt) {
-      this.pendingRotatedCourts.add(courtNumber);
+      CourtAssignmentTracker.pendingRotatedCourts.add(courtNumber);
       this.updateCourtTeamStats(rotatedCourt, court);
     }
 

--- a/src/hooks/useAnalytics.ts
+++ b/src/hooks/useAnalytics.ts
@@ -58,7 +58,7 @@ export const useAnalytics = (): AnalyticsHook => {
     trackEvent({
       action,
       category: 'Game Management',
-      label: details?.gameType || details?.courtNumber ? `Court ${details.courtNumber}` : undefined,
+      label: details?.gameType ?? (details?.courtNumber !== undefined ? `Court ${details.courtNumber}` : undefined),
       value: details?.courtNumber,
     });
   }, [trackEvent]);

--- a/src/providers/AppStateProvider.tsx
+++ b/src/providers/AppStateProvider.tsx
@@ -17,6 +17,9 @@ export function useAppState(): AppStateContextType {
 
 export function AppStateProvider({ children }: { children: React.ReactNode }): React.ReactElement {
   const [players, setPlayers] = useState<Player[]>([]);
+  const [numberOfCourts, setNumberOfCourts] = useState<number>(4);
+  const [assignments, setAssignments] = useState<Court[]>([]);
+  const [lastGeneratedAt, setLastGeneratedAt] = useState<number | undefined>();
   const [isLoaded, setIsLoaded] = useState(false);
   const [isSmartEngineEnabled, setIsSmartEngineEnabled] = useState(false);
   const [counts, setCounts] = useState({ wins: new Map<string, number>(), losses: new Map<string, number>(), bench: new Map<string, number>() });
@@ -30,6 +33,9 @@ export function AppStateProvider({ children }: { children: React.ReactNode }): R
       if (loadedState.players?.length) {
         setPlayers(loadedState.players);
       }
+      if (loadedState.numberOfCourts !== undefined) setNumberOfCourts(loadedState.numberOfCourts);
+      if (loadedState.assignments?.length) setAssignments(loadedState.assignments);
+      if (loadedState.lastGeneratedAt !== undefined) setLastGeneratedAt(loadedState.lastGeneratedAt);
       const smart = loadedState.isSmartEngineEnabled ?? false;
       if (smart) setIsSmartEngineEnabled(true);
       const engineType = smart ? 'sl' : 'sa';
@@ -52,8 +58,13 @@ export function AppStateProvider({ children }: { children: React.ReactNode }): R
 
   useEffect(() => {
     if (!hasLoadedRef.current) return;
-    storageManager.saveApp({ players, isSmartEngineEnabled });
-  }, [players, isSmartEngineEnabled]);
+    storageManager.saveApp({ players, isSmartEngineEnabled, numberOfCourts, assignments, lastGeneratedAt });
+  }, [players, isSmartEngineEnabled, numberOfCourts, assignments, lastGeneratedAt]);
+
+  useEffect(() => {
+    if (!hasLoadedRef.current || !engineState) return;
+    void storageManager.saveEngine(engineState);
+  }, [engineState]);
 
   const handleAddPlayers = (names: string[]) => {
     const newPlayers = createPlayersFromNames(names, 'manual');
@@ -93,10 +104,10 @@ export function AppStateProvider({ children }: { children: React.ReactNode }): R
     const courtsWithWinners = courts.filter(c => c.winner);
     if (courtsWithWinners.length > 0) {
       const nextPlayers = levelTracker.updatePlayersLevels(courtsWithWinners, players);
-      engine().recordLevelSnapshot(nextPlayers);
+      engine().recordLevelSnapshot(nextPlayers.filter(p => p.isPresent));
       setPlayers(nextPlayers);
     } else {
-      engine().recordLevelSnapshot(players);
+      engine().recordLevelSnapshot(players.filter(p => p.isPresent));
     }
   }, [players]);
 
@@ -132,6 +143,12 @@ export function AppStateProvider({ children }: { children: React.ReactNode }): R
 
   const value: AppStateContextType = {
     players,
+    numberOfCourts,
+    setNumberOfCourts,
+    assignments,
+    setAssignments,
+    lastGeneratedAt,
+    setLastGeneratedAt,
     isLoaded,
     handlePlayerToggle,
     handleAddPlayers,

--- a/src/tournament/EliminationTournament.ts
+++ b/src/tournament/EliminationTournament.ts
@@ -11,9 +11,11 @@ import type {
   TournamentTeam,
 } from './types';
 import { RoundRobinTournament } from './RoundRobinTournament';
+import type { SeedSlots } from './bracketTree';
 import {
   ConsolationBracket,
   WinnersBracket,
+  findMatchBetween,
   getCBExpectedPool,
   getWBSemiFinalLosers,
   getWinnersFirstRoundLoser,
@@ -98,74 +100,126 @@ export class EliminationTournament extends Tournament {
   }
 
   /**
-   * Builds the matches unlocked by the latest result: the next winners round,
-   * consolation rounds, and a 3rd-place match only when the semi-final round has
-   * two real matches — a lone semi-final loser is 3rd automatically.
+   * Builds the matches unlocked by the latest result: winners matches whose
+   * participants are known, consolation rounds, and a 3rd-place match only when
+   * the semi-final round has two real matches — a lone semi-final loser is 3rd
+   * automatically.
    */
   private generateFollowUpMatches(allMatches: TournamentMatch[]): TournamentMatch[] {
-    const { teams } = this._state;
-    const bracketSize = this.bracketSize();
-    const newMatches: TournamentMatch[] = [];
     const winnersMatches = allMatches.filter(m => m.bracket === BracketKind.Winners);
     const consolationMatches = allMatches.filter(m => m.bracket === BracketKind.Consolation);
-    const totalWBRounds = Math.log2(bracketSize);
+    const thirdPlaceExists = allMatches.some(m => m.bracket === BracketKind.ThirdPlace);
 
-    for (let n = 1; n < totalWBRounds; n++) {
-      if (!roundComplete(winnersMatches, n)) break;
-      if (this.roundExists(winnersMatches, n + 1)) continue;
+    const newWB = this.nextWinnersRoundMatches(winnersMatches, allMatches.length);
+    const newCB = this.nextConsolationMatches(
+      winnersMatches, consolationMatches, allMatches.length + newWB.length,
+    );
+    const newTP = thirdPlaceExists ? [] : this.nextThirdPlaceMatches(
+      [...winnersMatches, ...newWB], allMatches.length + newWB.length + newCB.length,
+    );
 
-      const nextRoundPositions = bracketSize / Math.pow(2, n + 1);
-      let courtIndex = allMatches.length + newMatches.length;
-      const winnersMatchesSoFar = [...winnersMatches, ...newMatches.filter(m => m.bracket === BracketKind.Winners)];
-      for (let pos = 0; pos < nextRoundPositions; pos++) {
-        const teamA = resolvePosition(n, 2 * pos, teams, winnersMatchesSoFar);
-        const teamB = resolvePosition(n, 2 * pos + 1, teams, winnersMatchesSoFar);
-        if (teamA !== 'bye' && teamA !== 'tbd' && teamB !== 'bye' && teamB !== 'tbd') {
-          newMatches.push(this.makeMatch(BracketKind.Winners, n + 1, teamA, teamB, courtIndex));
-          courtIndex++;
-        }
+    return [...newWB, ...newCB, ...newTP];
+  }
+
+  /**
+   * Generates each winners match as soon as both of its feeder slots are
+   * decided — without waiting for the rest of the round to finish.
+   */
+  private nextWinnersRoundMatches(
+    winnersMatches: TournamentMatch[],
+    startCourtIndex: number,
+  ): TournamentMatch[] {
+    const { teams } = this._state;
+    const bracketSize = this.bracketSize();
+    const totalWBRounds = this.totalRounds();
+    const newMatches: TournamentMatch[] = [];
+    let courtIndex = startCourtIndex;
+
+    for (let round = 2; round <= totalWBRounds; round++) {
+      const positions = bracketSize / Math.pow(2, round);
+      for (let pos = 0; pos < positions; pos++) {
+        const teamA = resolvePosition(round - 1, 2 * pos, teams, winnersMatches);
+        const teamB = resolvePosition(round - 1, 2 * pos + 1, teams, winnersMatches);
+        if (teamA === 'bye' || teamA === 'tbd' || teamB === 'bye' || teamB === 'tbd') continue;
+        if (findMatchBetween(round, teamA, teamB, winnersMatches)) continue;
+        newMatches.push(this.makeMatch(BracketKind.Winners, round, teamA, teamB, courtIndex));
+        courtIndex++;
       }
-      break;
     }
 
-    const cbSeeds: TournamentTeam[] = [];
-    for (let pos = 0; pos < bracketSize / 2; pos++) {
-      const loser = getWinnersFirstRoundLoser(pos, teams, winnersMatches);
-      if (loser) cbSeeds.push(loser);
-    }
+    return newMatches;
+  }
 
-    if (roundComplete(winnersMatches, 1) && !this.roundExists(consolationMatches, 1) && cbSeeds.length >= 2) {
-      newMatches.push(...this.pairTeamsIntoMatches(
-        BracketKind.Consolation, 1, cbSeeds, allMatches.length + newMatches.length,
+  /** True once every slot of the WB round has resolved to a team or a bye. */
+  private wbRoundFullyDecided(winnersMatches: TournamentMatch[], round: number): boolean {
+    const positions = this.bracketSize() / Math.pow(2, round);
+    for (let pos = 0; pos < positions; pos++) {
+      if (resolvePosition(round, pos, this._state.teams, winnersMatches) === 'tbd') return false;
+    }
+    return true;
+  }
+
+  /**
+   * One seed slot per real WB first-round match, in position order: the
+   * match's loser once decided, `null` until then. Bye positions get no slot.
+   */
+  private cbSeedSlots(winnersMatches: TournamentMatch[]): SeedSlots {
+    const { teams } = this._state;
+    const slots: Array<TournamentTeam | null> = [];
+    for (let pos = 0; pos < this.bracketSize() / 2; pos++) {
+      if (!teams[2 * pos] || !teams[2 * pos + 1]) continue;
+      slots.push(getWinnersFirstRoundLoser(pos, teams, winnersMatches));
+    }
+    return slots;
+  }
+
+  /**
+   * Seeds each consolation first-round match as soon as both paired WB losers
+   * are known, then advances completed CB rounds. Advancement waits for the
+   * full WB first round: the advancer pool (and its bye-passers) is only
+   * meaningful once every seed slot is filled.
+   */
+  private nextConsolationMatches(
+    winnersMatches: TournamentMatch[],
+    consolationMatches: TournamentMatch[],
+    startCourtIndex: number,
+  ): TournamentMatch[] {
+    const totalWBRounds = this.totalRounds();
+    const newMatches: TournamentMatch[] = [];
+
+    const slots = this.cbSeedSlots(winnersMatches);
+    for (let pair = 0; 2 * pair + 1 < slots.length; pair++) {
+      const teamA = slots[2 * pair];
+      const teamB = slots[2 * pair + 1];
+      if (!teamA || !teamB || findMatchBetween(1, teamA, teamB, consolationMatches)) continue;
+      newMatches.push(this.makeMatch(
+        BracketKind.Consolation, 1, teamA, teamB, startCourtIndex + newMatches.length,
       ));
     }
 
-    const maxCBRound = consolationMatches.length > 0 ? Math.max(...consolationMatches.map(m => m.round)) : 0;
+    if (!this.wbRoundFullyDecided(winnersMatches, 1)) return newMatches;
+
+    const cbSeeds = slots.filter((s): s is TournamentTeam => s !== null);
+    const allCB = [...consolationMatches, ...newMatches];
+    const maxCBRound = allCB.length > 0 ? Math.max(...allCB.map(m => m.round)) : 0;
 
     for (let n = 1; n <= maxCBRound; n++) {
-      if (!roundComplete(consolationMatches, n)) break;
-      if (this.roundExists(consolationMatches, n + 1)) continue;
+      if (!roundComplete(allCB, n)) break;
+      if (this.roundExists(allCB, n + 1)) continue;
 
-      const consolationMatchesSoFar = [
-        ...consolationMatches.filter(m => m.round === n),
-        ...newMatches.filter(m => m.bracket === BracketKind.Consolation && m.round === n),
-      ];
+      const cbRoundN = allCB.filter(m => m.round === n);
 
-      const advancers: TournamentTeam[] = consolationMatchesSoFar
+      const advancers: TournamentTeam[] = cbRoundN
         .filter(m => m.winner !== undefined)
         .map(m => m.winner === 1 ? m.team1 : m.team2);
 
-      const allCBSoFar = [
-        ...consolationMatches,
-        ...newMatches.filter(m => m.bracket === BracketKind.Consolation),
-      ];
-      const cbRnParticipantIds = new Set(consolationMatchesSoFar.flatMap(m => [m.team1.id, m.team2.id]));
-      const expectedPool = getCBExpectedPool(n, cbSeeds, allCBSoFar);
+      const cbRnParticipantIds = new Set(cbRoundN.flatMap(m => [m.team1.id, m.team2.id]));
+      const expectedPool = getCBExpectedPool(n, cbSeeds, allCB);
       for (const team of expectedPool) {
         if (!cbRnParticipantIds.has(team.id)) advancers.push(team);
       }
 
-      if (advancers.length < 2 && n + 1 < totalWBRounds && roundComplete(winnersMatches, n + 1)) {
+      if (advancers.length < 2 && n + 1 < totalWBRounds && this.wbRoundFullyDecided(winnersMatches, n + 1)) {
         for (const m of winnersMatches.filter(m => m.round === n + 1 && m.winner !== undefined)) {
           advancers.push(m.winner === 1 ? m.team2 : m.team1);
         }
@@ -173,28 +227,24 @@ export class EliminationTournament extends Tournament {
 
       if (advancers.length >= 2) {
         newMatches.push(...this.pairTeamsIntoMatches(
-          BracketKind.Consolation, n + 1, advancers, allMatches.length + newMatches.length,
+          BracketKind.Consolation, n + 1, advancers, startCourtIndex + newMatches.length,
         ));
       }
       break;
     }
 
-    const thirdPlaceExists = allMatches.some(m => m.bracket === BracketKind.ThirdPlace)
-      || newMatches.some(m => m.bracket === BracketKind.ThirdPlace);
-    const semiFinalRound = totalWBRounds - 1;
-    const allWB = [...winnersMatches, ...newMatches.filter(m => m.bracket === BracketKind.Winners)];
-
-    if (!thirdPlaceExists && semiFinalRound >= 2 && roundComplete(allWB, semiFinalRound)) {
-      const sfLosers = getWBSemiFinalLosers(allWB, totalWBRounds);
-      if (sfLosers.length === 2) {
-        newMatches.push(this.makeMatch(
-          BracketKind.ThirdPlace, 1, sfLosers[0], sfLosers[1],
-          allMatches.length + newMatches.length,
-        ));
-      }
-    }
-
     return newMatches;
+  }
+
+  /** Creates the 3rd-place match once both semi-finals are decided. */
+  private nextThirdPlaceMatches(allWB: TournamentMatch[], courtIndex: number): TournamentMatch[] {
+    const totalWBRounds = this.totalRounds();
+    const semiFinalRound = totalWBRounds - 1;
+    if (semiFinalRound < 2 || !roundComplete(allWB, semiFinalRound)) return [];
+
+    const sfLosers = getWBSemiFinalLosers(allWB, totalWBRounds);
+    if (sfLosers.length !== 2) return [];
+    return [this.makeMatch(BracketKind.ThirdPlace, 1, sfLosers[0], sfLosers[1], courtIndex)];
   }
 
   start(teams: TournamentTeam[], numberOfCourts: number): EliminationTournament {
@@ -210,13 +260,39 @@ export class EliminationTournament extends Tournament {
     winner: 1 | 2,
     score?: { team1: number; team2: number },
   ): this {
-    const updatedMatches = this._state.matches.map(m =>
+    const existing = this._state.matches.find(m => m.id === matchId);
+    if (!existing) return this;
+
+    let updatedMatches = this._state.matches.map(m =>
       m.id === matchId ? { ...m, winner, score: score ?? m.score } : m,
     );
+    if (existing.winner !== undefined && existing.winner !== winner) {
+      updatedMatches = this.withoutDependentMatches(updatedMatches, existing);
+    }
     const followUp = this.generateFollowUpMatches(updatedMatches);
     const allMatches = [...updatedMatches, ...followUp];
     const phase = allMatches.length > 0 && allMatches.every(m => m.winner !== undefined) ? 'completed' : 'active';
     return new EliminationTournament({ ...this._state, matches: allMatches, phase }) as unknown as this;
+  }
+
+  /**
+   * Drops matches whose participants were derived from the changed match's old
+   * result, so generateFollowUpMatches can rebuild them with the corrected team:
+   * later rounds of the same bracket, and — for a winners-bracket change before
+   * the final — the consolation rounds fed by it and the 3rd-place match.
+   */
+  private withoutDependentMatches(
+    matches: TournamentMatch[],
+    changed: TournamentMatch,
+  ): TournamentMatch[] {
+    const { bracket, round } = changed;
+    const finalRound = this.totalRounds();
+    return matches.filter(m => {
+      if (m.bracket === bracket) return m.round <= round;
+      if (bracket !== BracketKind.Winners || round >= finalRound) return true;
+      if (m.bracket === BracketKind.Consolation) return m.round < round;
+      return false;
+    });
   }
 
   get winners(): WinnersBracket {
@@ -233,7 +309,7 @@ export class EliminationTournament extends Tournament {
 
   get consolation(): ConsolationBracket {
     return new ConsolationBracket(
-      this.winners.firstRoundLosers(),
+      this.cbSeedSlots(this._state.matches.filter(m => m.bracket === BracketKind.Winners)),
       this._state.matches.filter(m => m.bracket === BracketKind.Consolation),
       this.bracketSize(),
     );

--- a/src/tournament/bracketTree.ts
+++ b/src/tournament/bracketTree.ts
@@ -16,7 +16,7 @@ export function nextPowerOf2(n: number): number {
   return p;
 }
 
-function findMatchBetween(
+export function findMatchBetween(
   round: number,
   teamA: TournamentTeam,
   teamB: TournamentTeam,
@@ -30,6 +30,13 @@ function findMatchBetween(
 }
 
 type PositionResult = TournamentTeam | 'bye' | 'tbd';
+
+/**
+ * Seed slots of a bracket's first round: a team once known, `null` while the
+ * slot's feeder match is undecided (consolation only), `undefined` past the
+ * end of the array meaning no slot at all (a bye).
+ */
+export type SeedSlots = ReadonlyArray<TournamentTeam | null>;
 
 function resolveChildNode(
   round: number,
@@ -50,18 +57,19 @@ function resolveChildNode(
 export function resolvePosition(
   round: number,
   position: number,
-  seeds: TournamentTeam[],
+  seeds: SeedSlots,
   matches: TournamentMatch[],
 ): PositionResult {
   if (round === 1) {
-    const team1 = seeds[2 * position];
-    const team2 = seeds[2 * position + 1];
+    const slotA = seeds[2 * position];
+    const slotB = seeds[2 * position + 1];
 
-    if (!team1 && !team2) return 'bye';
-    if (!team1) return team2;
-    if (!team2) return team1;
+    if (slotA === undefined && slotB === undefined) return 'bye';
+    if (slotA === undefined) return slotB ?? 'tbd';
+    if (slotB === undefined) return slotA ?? 'tbd';
+    if (slotA === null || slotB === null) return 'tbd';
 
-    const match = findMatchBetween(1, team1, team2, matches);
+    const match = findMatchBetween(1, slotA, slotB, matches);
     if (!match || match.winner === undefined) return 'tbd';
     return match.winner === 1 ? match.team1 : match.team2;
   }
@@ -83,7 +91,7 @@ export function roundComplete(matches: TournamentMatch[], round: number): boolea
 
 export function getWinnersFirstRoundLoser(
   position: number,
-  teams: TournamentTeam[],
+  teams: SeedSlots,
   winnersMatches: TournamentMatch[],
 ): TournamentTeam | null {
   const team1 = teams[2 * position];
@@ -141,18 +149,23 @@ export function roundLabel(roundNumber: number, totalRounds: number): string {
 function buildNode(
   round: number,
   position: number,
-  seeds: TournamentTeam[],
+  seeds: SeedSlots,
   matches: TournamentMatch[],
 ): BracketNode {
   if (round === 1) {
-    const team1 = seeds[2 * position];
-    const team2 = seeds[2 * position + 1];
+    const slotA = seeds[2 * position];
+    const slotB = seeds[2 * position + 1];
 
-    if (!team1 && !team2) return { type: 'empty', slotIndex: position };
-    if (!team1) return { type: 'bye-advance', team: team2, slotIndex: position };
-    if (!team2) return { type: 'bye-advance', team: team1, slotIndex: position };
+    if (slotA === undefined && slotB === undefined) return { type: 'empty', slotIndex: position };
+    if (slotA === undefined) {
+      return slotB ? { type: 'bye-advance', team: slotB, slotIndex: position } : { type: 'tbd', slotIndex: position };
+    }
+    if (slotB === undefined) {
+      return slotA ? { type: 'bye-advance', team: slotA, slotIndex: position } : { type: 'tbd', slotIndex: position };
+    }
+    if (slotA === null || slotB === null) return { type: 'tbd', slotIndex: position };
 
-    const match = findMatchBetween(1, team1, team2, matches);
+    const match = findMatchBetween(1, slotA, slotB, matches);
     if (!match) return { type: 'tbd', slotIndex: position };
     return { type: 'match', match, slotIndex: position };
   }
@@ -178,7 +191,7 @@ function buildNode(
 
 export abstract class Bracket {
   constructor(
-    protected readonly _seeds: TournamentTeam[],
+    protected readonly _seeds: SeedSlots,
     protected readonly _matches: TournamentMatch[],
     protected readonly _bracketSize: number,
   ) {}
@@ -240,18 +253,23 @@ export class WinnersBracket extends Bracket {
   }
 }
 
-/** Consolation bracket — for teams eliminated in the winners bracket first round. */
+/**
+ * Consolation bracket — for teams eliminated in the winners bracket first
+ * round. Seeds are positional slots (one per real WB first-round match), with
+ * `null` marking a loser not yet known, so the tree shape is stable while the
+ * WB first round is still in progress.
+ */
 export class ConsolationBracket extends Bracket {
   private readonly cbBracketSize: number;
   private readonly cbSeedRounds: number;
 
-  constructor(seeds: TournamentTeam[], matches: TournamentMatch[], bracketSize: number) {
+  constructor(seeds: SeedSlots, matches: TournamentMatch[], bracketSize: number) {
     super(seeds, matches, bracketSize);
     this.cbBracketSize = nextPowerOf2(seeds.length);
     this.cbSeedRounds = Math.log2(this.cbBracketSize);
   }
 
-  seeds(): TournamentTeam[] {
+  seeds(): SeedSlots {
     return this._seeds;
   }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -104,6 +104,12 @@ export interface ICourtAssignmentEngine extends ICourtAssignmentTracker {
 
 export interface AppStateContextType {
   players: Player[];
+  numberOfCourts: number;
+  setNumberOfCourts: React.Dispatch<React.SetStateAction<number>>;
+  assignments: Court[];
+  setAssignments: React.Dispatch<React.SetStateAction<Court[]>>;
+  lastGeneratedAt?: number;
+  setLastGeneratedAt: React.Dispatch<React.SetStateAction<number | undefined>>;
   isLoaded: boolean;
   handlePlayerToggle: (id: string) => void;
   handleAddPlayers: (names: string[]) => void;

--- a/src/utils/StorageManager.ts
+++ b/src/utils/StorageManager.ts
@@ -16,11 +16,12 @@ interface StorageData {
  *
  * Fields:
  *   v   — format version (3)
- *   et  — engine type ('sa' | 'mc' | 'cg' | 'sl')
+ *   et  — engine type ('sa' | 'sl')
  *   pi  — player ID index: pi[i] = playerId
  *   ps  — per-player stats, same order as pi: [bench, single, win, loss]
  *   pc  — pair counts keyed "i:j" (i < j): [teammate, opponent]
  *   lh  — level history per pi index (capped at MAX_LEVEL_HISTORY entries)
+ *   rp  — rounds played (rounds committed with at least one winner)
  */
 interface CompactEngineState {
   v: 3;
@@ -30,6 +31,7 @@ interface CompactEngineState {
   ps: Array<[number, number, number, number]>;
   pc: Record<string, [number, number]>;
   lh?: number[][];
+  rp?: number;
 }
 
 export async function readAllChunks(reader: ReadableStreamDefaultReader<Uint8Array>): Promise<Uint8Array> {
@@ -74,48 +76,8 @@ export async function decompress(data: string): Promise<string> {
 
 /**
  * Manages persistence of application and engine state using a single
- * gzip-compressed, base64-encoded localStorage entry.
- *
- * Stored JSON structure (after decompression):
- * ```json
- * {
- *   "app": {
- *     "players":        [{ "id": "uuid", "name": "Alice", "isPresent": true, "level": 72 }, ...],
- *     "numberOfCourts": 4,
- *     "assignments":    [...],
- *     "lastGeneratedAt": 1710000000000,
- *     "isSmartEngineEnabled": false
- *   },
- *   "tournament": {
- *     "phase": "active",
- *     "format": "singles",
- *     "type": "round-robin",
- *     "numberOfCourts": 2,
- *     "teams": [...],
- *     "matches": [...]
- *   },
- *   "engine": {
- *     "v":  3,
- *     "et": "sa",
- *     "pi": ["uuid-A", "uuid-B", "uuid-C"],
- *     "ps": [
- *       [bench, single, win, loss],   ←  pi[0] = uuid-A
- *       [bench, single, win, loss],   ←  pi[1] = uuid-B
- *       [bench, single, win, loss]    ←  pi[2] = uuid-C
- *     ],
- *     "pc": {
- *       "0:1": [teammate, opponent],  ←  uuid-A × uuid-B
- *       "0:2": [teammate, opponent],  ←  uuid-A × uuid-C
- *       "1:2": [teammate, opponent]   ←  uuid-B × uuid-C
- *     },
- *     "lh": [
- *       [55, 58, 61],   ←  pi[0] level history (capped at 10)
- *       [50, 49],       ←  pi[1]
- *       []              ←  pi[2] (no history yet)
- *     ]
- *   }
- * }
- * ```
+ * gzip-compressed, base64-encoded localStorage entry holding
+ * `{ app: AppState, engine: CompactEngineState, tournament?: TournamentState }`.
  *
  * All writes are serialised through an internal promise queue so that
  * concurrent `saveApp` / `saveEngine` calls never race on read→modify→write.
@@ -190,7 +152,7 @@ class StorageManager {
     if ((raw as CompactEngineState).v === 3) {
       try {
         return this.fromCompact(raw as CompactEngineState);
-      } catch { /* corrupt v3 — fall through to discard */ }
+      } catch {  }
     }
 
     const { engine: _, ...rest } = data;
@@ -321,7 +283,7 @@ class StorageManager {
       lh = pi.map(id => state.levelHistory![id] ?? []);
     }
 
-    return { v: 3, et: state.engineType, ts: state.savedAt, pi, ps, pc, lh };
+    return { v: 3, et: state.engineType, ts: state.savedAt, pi, ps, pc, lh, rp: state.roundsPlayed };
   }
 
   private fromCompact(c: CompactEngineState): CourtEngineState {
@@ -369,6 +331,7 @@ class StorageManager {
     return {
       engineType: c.et,
       savedAt: c.ts,
+      roundsPlayed: c.rp,
       benchCountMap, singleCountMap,
       teammateCountMap, opponentCountMap,
       winCountMap, lossCountMap,
@@ -414,7 +377,7 @@ class StorageManager {
 
     const allKeys = Object.keys(engine.pc ?? {});
     if (allKeys.length > 200) {
-      return rebuild({ ...engine, pc: Object.fromEntries(allKeys.slice(0, 200).map(k => [k, engine.pc[k]])) });
+      return rebuild({ ...engine, pc: Object.fromEntries(allKeys.slice(-200).map(k => [k, engine.pc[k]])) });
     }
 
     console.warn('StorageManager: pruneToFit could not reduce payload below MAX_SIZE');

--- a/src/utils/ocrEngine.ts
+++ b/src/utils/ocrEngine.ts
@@ -22,49 +22,53 @@ export async function recognizePlayerNames(
   pushProgress(0.1);
 
   const { createWorker } = await import('tesseract.js');
-  const worker: any = await (createWorker as any)('eng', workerPath ? { workerPath } : undefined);
+  const worker: any = await (createWorker as any)('eng', 1, {
+    ...(workerPath ? { workerPath } : {}),
+    logger: (m: any) => {
+      if (m.status === 'recognizing text') {
+        pushProgress(0.6 + (m.progress * 0.4));
+      }
+    },
+  });
 
   pushProgress(0.2);
 
-  worker.logger = (m: any) => {
-    if (m.status === 'recognizing text') {
-      pushProgress(0.6 + (m.progress * 0.4));
+  try {
+    if (typeof worker.setParameters === 'function') {
+      await worker.setParameters({
+        tessedit_char_whitelist: 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz ',
+        preserve_interword_spaces: '1',
+        tessedit_pageseg_mode: '11',
+        user_defined_dpi: '300',
+      });
     }
-  };
 
-  if (typeof worker.setParameters === 'function') {
-    await worker.setParameters({
-      tessedit_char_whitelist: 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz ',
-      preserve_interword_spaces: '1',
-      tessedit_pageseg_mode: '11',
-      user_defined_dpi: '300',
-    });
-  }
+    pushProgress(0.3);
 
-  pushProgress(0.3);
+    let imageForOCR: any = image;
+    if (shouldPreprocess && image instanceof File) {
+      try {
+        pushProgress(0.35);
 
-  let imageForOCR: any = image;
-  if (shouldPreprocess && image instanceof File) {
-    try {
-      pushProgress(0.35);
+        imageForOCR = await preprocessImage(image);
 
-      imageForOCR = await preprocessImage(image);
-
-      pushProgress(0.6);
-    } catch (err) {
-      console.warn('Image preprocessing skipped:', err);
+        pushProgress(0.6);
+      } catch (err) {
+        console.warn('Image preprocessing skipped:', err);
+        pushProgress(0.6);
+      }
+    } else {
       pushProgress(0.6);
     }
-  } else {
-    pushProgress(0.6);
+
+    const {
+      data: { text },
+    } = await worker.recognize(imageForOCR);
+
+    return extractPlayerNames(text);
+  } finally {
+    await worker.terminate();
   }
-
-  const {
-    data: { text },
-  } = await worker.recognize(imageForOCR);
-  await worker.terminate();
-
-  return extractPlayerNames(text);
 }
 
 export function extractPlayerNames(text: string): string[] {

--- a/tests/components/modals/ImageUploadModal.test.tsx
+++ b/tests/components/modals/ImageUploadModal.test.tsx
@@ -56,6 +56,28 @@ describe('ImageUploadModal', () => {
     );
   };
 
+  /** Renders the modal and simulates OCR extraction of the given player names. */
+  const renderWithExtractedPlayers = async (players: string[]) => {
+    let extractionCallback: ((players: string[]) => void) | undefined;
+
+    vi.mocked(useImageOcr).mockImplementation(({ onPlayersExtracted }) => {
+      extractionCallback = onPlayersExtracted;
+      return {
+        isProcessing: false,
+        progress: 0,
+        processImage: vi.fn(),
+      };
+    });
+
+    const result = renderModal();
+
+    await act(async () => {
+      extractionCallback!(players);
+    });
+
+    return result;
+  };
+
   describe('Modal visibility', () => {
     it('should not render when isOpen is false', () => {
       renderModal(false);
@@ -154,30 +176,7 @@ describe('ImageUploadModal', () => {
 
   describe('Extracted players list', () => {
     it('should display count of extracted players', async () => {
-      let extractionCallback: ((players: string[]) => void) | undefined;
-
-      vi.mocked(useImageOcr).mockImplementation(({ onPlayersExtracted }) => {
-        extractionCallback = onPlayersExtracted;
-        return {
-          isProcessing: false,
-          progress: 0,
-          processImage: vi.fn(),
-        };
-      });
-
-      const { rerender } = renderModal();
-
-      await act(async () => {
-        extractionCallback(['Alice', 'Bob']);
-      });
-
-      rerender(
-        <ImageUploadModal
-          isOpen={true}
-          onClose={mockOnClose}
-          onPlayersAdded={mockOnPlayersAdded}
-        />,
-      );
+      await renderWithExtractedPlayers(['Alice', 'Bob']);
 
       await waitFor(() => {
         expect(screen.getByText(/Found/)).toBeInTheDocument();
@@ -185,30 +184,7 @@ describe('ImageUploadModal', () => {
     });
 
     it('should have select all and deselect all buttons', async () => {
-      let extractionCallback: ((players: string[]) => void) | undefined;
-
-      vi.mocked(useImageOcr).mockImplementation(({ onPlayersExtracted }) => {
-        extractionCallback = onPlayersExtracted;
-        return {
-          isProcessing: false,
-          progress: 0,
-          processImage: vi.fn(),
-        };
-      });
-
-      const { rerender } = renderModal();
-
-      await act(async () => {
-        extractionCallback(['Alice', 'Bob']);
-      });
-
-      rerender(
-        <ImageUploadModal
-          isOpen={true}
-          onClose={mockOnClose}
-          onPlayersAdded={mockOnPlayersAdded}
-        />,
-      );
+      await renderWithExtractedPlayers(['Alice', 'Bob']);
 
       await waitFor(() => {
         expect(screen.getByText('Select all')).toBeInTheDocument();
@@ -216,31 +192,17 @@ describe('ImageUploadModal', () => {
       });
     });
 
+    it('should keep the file input mounted so "Try another image" can open the picker', async () => {
+      await renderWithExtractedPlayers(['Alice', 'Bob']);
+
+      await waitFor(() => {
+        expect(screen.getByText('📸 Try another image')).toBeInTheDocument();
+      });
+      expect(screen.getByTestId('image-file-input')).toBeInTheDocument();
+    });
+
     it('should have a try another image button when players are extracted', async () => {
-      let extractionCallback: ((players: string[]) => void) | undefined;
-
-      vi.mocked(useImageOcr).mockImplementation(({ onPlayersExtracted }) => {
-        extractionCallback = onPlayersExtracted;
-        return {
-          isProcessing: false,
-          progress: 0,
-          processImage: vi.fn(),
-        };
-      });
-
-      const { rerender } = renderModal();
-
-      await act(async () => {
-        extractionCallback(['Alice']);
-      });
-
-      rerender(
-        <ImageUploadModal
-          isOpen={true}
-          onClose={mockOnClose}
-          onPlayersAdded={mockOnPlayersAdded}
-        />,
-      );
+      await renderWithExtractedPlayers(['Alice']);
 
       await waitFor(() => {
         expect(screen.getByText('📸 Try another image')).toBeInTheDocument();
@@ -250,30 +212,7 @@ describe('ImageUploadModal', () => {
 
   describe('Add players functionality', () => {
     it('should have an add players button when players are extracted', async () => {
-      let extractionCallback: ((players: string[]) => void) | undefined;
-
-      vi.mocked(useImageOcr).mockImplementation(({ onPlayersExtracted }) => {
-        extractionCallback = onPlayersExtracted;
-        return {
-          isProcessing: false,
-          progress: 0,
-          processImage: vi.fn(),
-        };
-      });
-
-      const { rerender } = renderModal();
-
-      await act(async () => {
-        extractionCallback(['Alice', 'Bob']);
-      });
-
-      rerender(
-        <ImageUploadModal
-          isOpen={true}
-          onClose={mockOnClose}
-          onPlayersAdded={mockOnPlayersAdded}
-        />,
-      );
+      await renderWithExtractedPlayers(['Alice', 'Bob']);
 
       await waitFor(() => {
         expect(screen.getByTestId('add-extracted-players-button')).toBeInTheDocument();
@@ -281,30 +220,7 @@ describe('ImageUploadModal', () => {
     });
 
     it('should call onPlayersAdded when clicking add button with selected players', async () => {
-      let extractionCallback: ((players: string[]) => void) | undefined;
-
-      vi.mocked(useImageOcr).mockImplementation(({ onPlayersExtracted }) => {
-        extractionCallback = onPlayersExtracted;
-        return {
-          isProcessing: false,
-          progress: 0,
-          processImage: vi.fn(),
-        };
-      });
-
-      const { rerender } = renderModal();
-
-      await act(async () => {
-        extractionCallback(['Alice', 'Bob']);
-      });
-
-      rerender(
-        <ImageUploadModal
-          isOpen={true}
-          onClose={mockOnClose}
-          onPlayersAdded={mockOnPlayersAdded}
-        />,
-      );
+      await renderWithExtractedPlayers(['Alice', 'Bob']);
 
       await waitFor(() => {
         expect(screen.getByTestId('add-extracted-players-button')).toBeInTheDocument();
@@ -317,30 +233,7 @@ describe('ImageUploadModal', () => {
     });
 
     it('should have cancel button in footer', async () => {
-      let extractionCallback: ((players: string[]) => void) | undefined;
-
-      vi.mocked(useImageOcr).mockImplementation(({ onPlayersExtracted }) => {
-        extractionCallback = onPlayersExtracted;
-        return {
-          isProcessing: false,
-          progress: 0,
-          processImage: vi.fn(),
-        };
-      });
-
-      const { rerender } = renderModal();
-
-      await act(async () => {
-        extractionCallback(['Alice']);
-      });
-
-      rerender(
-        <ImageUploadModal
-          isOpen={true}
-          onClose={mockOnClose}
-          onPlayersAdded={mockOnPlayersAdded}
-        />,
-      );
+      await renderWithExtractedPlayers(['Alice']);
 
       await waitFor(() => {
         expect(screen.getByText('Cancel')).toBeInTheDocument();

--- a/tests/components/tournament/elimination/EliminationBracket.test.tsx
+++ b/tests/components/tournament/elimination/EliminationBracket.test.tsx
@@ -49,7 +49,7 @@ describe('EliminationBracket', () => {
       );
       render(<EliminationBracket tournament={t} onMatchResult={onMatchResult} />);
       expect(screen.getByTestId('bracket-round-label-4th-of-Final')).toBeInTheDocument();
-      expect(screen.getByTestId('bracket-round-label-Semi-Final')).toBeInTheDocument();
+      expect(screen.getAllByTestId('bracket-round-label-Semi-Final').length).toBeGreaterThan(0);
     });
   });
 
@@ -158,6 +158,21 @@ describe('EliminationBracket', () => {
   });
 
   describe('consolation bracket', () => {
+    it('shows CB slots as TBD (never as false byes) while WB R1 is partially decided', () => {
+      let t = EliminationTournament.create('singles').start(
+        makeTeams(['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']), 4,
+      );
+      const [m0, , m2] = t.winners.matchesForRound(1);
+      t = t.withMatchResult(m0.id, 1);
+      t = t.withMatchResult(m2.id, 1);
+
+      render(<EliminationBracket tournament={t} onMatchResult={onMatchResult} />);
+      const cbSection = screen.getByTestId('cb-section');
+      expect(cbSection.querySelectorAll('[data-testid="bracket-node-tbd"]').length).toBeGreaterThan(0);
+      expect(cbSection.querySelectorAll('[data-testid="bracket-node-bye"]').length).toBe(0);
+      expect(cbSection.querySelectorAll('[data-testid="bracket-node-match"]').length).toBe(0);
+    });
+
     it('shows CB section after WB R1 is complete', async () => {
       const [A, B, C, D] = makeTeams(['A', 'B', 'C', 'D']);
       let t = EliminationTournament.create('singles').start([A, B, C, D], 4);

--- a/tests/components/tournament/round-robin/RoundRobinMatches.test.tsx
+++ b/tests/components/tournament/round-robin/RoundRobinMatches.test.tsx
@@ -76,6 +76,27 @@ describe('RoundRobinMatches', () => {
       expect(screen.getByText('Alice')).toBeInTheDocument();
       expect(screen.getByText('Bob')).toBeInTheDocument();
     });
+
+    it('clicking the current round header collapses it', async () => {
+      const user = userEvent.setup();
+      render(<RoundRobinMatches tournament={threeMatchSingles} onMatchResult={onMatchResult} />);
+
+      expect(screen.getByTestId('round-matches')).toBeInTheDocument();
+
+      await user.click(screen.getByTestId('round-header-1'));
+
+      expect(screen.queryByTestId('round-matches')).not.toBeInTheDocument();
+    });
+
+    it('a collapsed current round can be expanded again', async () => {
+      const user = userEvent.setup();
+      render(<RoundRobinMatches tournament={threeMatchSingles} onMatchResult={onMatchResult} />);
+
+      await user.click(screen.getByTestId('round-header-1'));
+      await user.click(screen.getByTestId('round-header-1'));
+
+      expect(screen.getByTestId('round-matches')).toBeInTheDocument();
+    });
   });
 
   describe('score modal', () => {

--- a/tests/engines/CourtAssignmentTracker.test.ts
+++ b/tests/engines/CourtAssignmentTracker.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { CourtAssignmentTracker } from '../../src/engines/CourtAssignmentTracker';
+import { createMockPlayers } from '../data/testFactories';
+import type { Court } from '../../src/types';
+
+describe('CourtAssignmentTracker', () => {
+  describe('removePlayerHistory', () => {
+    const tracker = new CourtAssignmentTracker();
+    const [alice, bob, carol, dave] = createMockPlayers(4);
+    const court: Court = {
+      courtNumber: 1,
+      players: [alice, bob, carol, dave],
+      teams: { team1: [alice, bob], team2: [carol, dave] },
+      winner: 1,
+    };
+
+    beforeEach(() => {
+      tracker.resetHistory();
+      tracker.applyRoundStats([court], [alice, bob, carol, dave]);
+      tracker.recordWins([court]);
+      tracker.recordLevelSnapshot([alice, bob, carol, dave]);
+    });
+
+    const pairKeysContaining = (map: Record<string, number>, playerId: string) =>
+      Object.keys(map).filter(key => key.split('|').includes(playerId));
+
+    it('removes win/loss/bench/single counts for the player', () => {
+      tracker.removePlayerHistory(alice.id);
+
+      const state = tracker.prepareStateForSaving('sa');
+      expect(state.winCountMap[alice.id]).toBeUndefined();
+      expect(state.lossCountMap[alice.id]).toBeUndefined();
+      expect(state.benchCountMap[alice.id]).toBeUndefined();
+      expect(state.singleCountMap[alice.id]).toBeUndefined();
+    });
+
+    it('removes teammate and opponent pair counts involving the player', () => {
+      tracker.removePlayerHistory(alice.id);
+
+      const state = tracker.prepareStateForSaving('sa');
+      expect(pairKeysContaining(state.teammateCountMap, alice.id)).toEqual([]);
+      expect(pairKeysContaining(state.opponentCountMap, alice.id)).toEqual([]);
+    });
+
+    it('removes the player level history', () => {
+      tracker.removePlayerHistory(alice.id);
+
+      const state = tracker.prepareStateForSaving('sa');
+      expect(state.levelHistory?.[alice.id]).toBeUndefined();
+    });
+
+    it('keeps data of the other players', () => {
+      tracker.removePlayerHistory(alice.id);
+
+      const state = tracker.prepareStateForSaving('sa');
+      expect(state.winCountMap[bob.id]).toBe(1);
+      expect(state.lossCountMap[carol.id]).toBe(1);
+      expect(state.teammateCountMap[[carol.id, dave.id].sort().join('|')]).toBe(1);
+      expect(state.levelHistory?.[bob.id]).toBeDefined();
+    });
+  });
+});

--- a/tests/hooks/useAnalytics.test.ts
+++ b/tests/hooks/useAnalytics.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+import { useAnalytics } from '../../src/hooks/useAnalytics';
+
+describe('useAnalytics', () => {
+  let gtag: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    gtag = vi.fn();
+    window.gtag = gtag;
+  });
+
+  afterEach(() => {
+    delete (window as { gtag?: unknown }).gtag;
+  });
+
+  describe('trackGameAction', () => {
+    it('uses gameType as the label when provided', () => {
+      const { result } = renderHook(() => useAnalytics());
+
+      result.current.trackGameAction('set_winner', { gameType: 'with_score', courtNumber: 2 });
+
+      expect(gtag).toHaveBeenCalledWith('event', 'set_winner', {
+        event_category: 'Game Management',
+        event_label: 'with_score',
+        value: 2,
+      });
+    });
+
+    it('falls back to a court label when only courtNumber is provided', () => {
+      const { result } = renderHook(() => useAnalytics());
+
+      result.current.trackGameAction('rotate_teams', { courtNumber: 3 });
+
+      expect(gtag).toHaveBeenCalledWith('event', 'rotate_teams', {
+        event_category: 'Game Management',
+        event_label: 'Court 3',
+        value: 3,
+      });
+    });
+
+    it('omits the label when no details are provided', () => {
+      const { result } = renderHook(() => useAnalytics());
+
+      result.current.trackGameAction('reset_algorithm');
+
+      expect(gtag).toHaveBeenCalledWith('event', 'reset_algorithm', {
+        event_category: 'Game Management',
+        event_label: undefined,
+        value: undefined,
+      });
+    });
+  });
+});

--- a/tests/pages/StatsPage.test.tsx
+++ b/tests/pages/StatsPage.test.tsx
@@ -21,6 +21,7 @@ vi.mock('../../src/engines/engineSelector', () => ({
     description: 'Test engine description',
     stats: vi.fn(() => ({ winCountMap: new Map(), lossCountMap: new Map(), benchCountMap: new Map(), singleCountMap: new Map(), teammateCountMap: new Map(), opponentCountMap: new Map(), roundsPlayed: 0 })),
     levelTrend: vi.fn(() => null),
+    saveState: vi.fn(() => Promise.resolve()),
   }),
   getEngineType: vi.fn(() => 'sa'),
   setEngine: vi.fn(),

--- a/tests/tournament/EliminationTournament.test.ts
+++ b/tests/tournament/EliminationTournament.test.ts
@@ -147,6 +147,47 @@ describe('EliminationTournament', () => {
       expect(t.consolation.matchesForRound(1)).toHaveLength(2);
     });
 
+    it('8 teams: a semi-final appears as soon as both of its feeder matches are decided', () => {
+      const teams = createTournamentTeams(['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']);
+      let t = EliminationTournament.create().start(teams, 4);
+      const [m0, m1, m2, m3] = t.winners.matchesForRound(1);
+
+      t = t.withMatchResult(m0.id, 1);
+      expect(t.winners.matchesForRound(2)).toHaveLength(0);
+
+      t = t.withMatchResult(m1.id, 1);
+      const r2 = t.winners.matchesForRound(2);
+      expect(r2).toHaveLength(1);
+      expect(new Set([r2[0].team1.id, r2[0].team2.id])).toEqual(new Set([m0.team1.id, m1.team1.id]));
+      expect(t.consolation.matchesForRound(1)).toHaveLength(1);
+
+      t = t.withMatchResult(m2.id, 1);
+      expect(t.winners.matchesForRound(2)).toHaveLength(1);
+
+      t = t.withMatchResult(m3.id, 1);
+      expect(t.winners.matchesForRound(2)).toHaveLength(2);
+      expect(t.consolation.matchesForRound(1)).toHaveLength(2);
+    });
+
+    it('8 teams: a decided semi-final does not duplicate when later results come in', () => {
+      const teams = createTournamentTeams(['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']);
+      let t = EliminationTournament.create().start(teams, 4);
+      const [m0, m1, m2, m3] = t.winners.matchesForRound(1);
+
+      t = t.withMatchResult(m0.id, 1);
+      t = t.withMatchResult(m1.id, 1);
+      const [sf0] = t.winners.matchesForRound(2);
+      t = t.withMatchResult(sf0.id, 1);
+
+      t = t.withMatchResult(m2.id, 1);
+      t = t.withMatchResult(m3.id, 1);
+
+      const r2 = t.winners.matchesForRound(2);
+      expect(r2).toHaveLength(2);
+      expect(r2.filter(m => m.id === sf0.id)).toHaveLength(1);
+      expect(t.winners.matchesForRound(3)).toHaveLength(0);
+    });
+
     it('8 teams: WB R2 complete → WB R3 (1 match) + CB R2 (1 match)', () => {
       const teams = createTournamentTeams(['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']);
       let t = EliminationTournament.create().start(teams, 4);
@@ -221,6 +262,78 @@ describe('EliminationTournament', () => {
       const r2TeamIds = [r2[0].team1.id, r2[0].team2.id];
       expect(r2TeamIds).toContain(m0.team1.id);
       expect(r2TeamIds).toContain(byeTeam.id);
+    });
+  });
+
+  describe('consolation bracket — per-pair seeding and stable tree', () => {
+    function start8() {
+      return EliminationTournament.create().start(
+        createTournamentTeams(['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']), 4,
+      );
+    }
+
+    it('8 teams: a CB R1 match appears as soon as both paired WB R1 losers are known', () => {
+      let t = start8();
+      const [m0, m1, m2] = t.winners.matchesForRound(1);
+
+      t = t.withMatchResult(m0.id, 1);
+      expect(t.consolation.matchesForRound(1)).toHaveLength(0);
+
+      t = t.withMatchResult(m1.id, 1);
+      const cb1 = t.consolation.matchesForRound(1);
+      expect(cb1).toHaveLength(1);
+      expect(new Set([cb1[0].team1.id, cb1[0].team2.id])).toEqual(new Set([m0.team2.id, m1.team2.id]));
+
+      t = t.withMatchResult(m2.id, 1);
+      expect(t.consolation.matchesForRound(1)).toHaveLength(1);
+    });
+
+    it('8 teams: CB does not advance to R2 before WB R1 is fully decided', () => {
+      let t = start8();
+      const [m0, m1] = t.winners.matchesForRound(1);
+      t = t.withMatchResult(m0.id, 1);
+      t = t.withMatchResult(m1.id, 1);
+
+      const [cb0] = t.consolation.matchesForRound(1);
+      t = t.withMatchResult(cb0.id, 1);
+
+      expect(t.consolation.matchesForRound(2)).toHaveLength(0);
+    });
+
+    it('8 teams: finishing WB R1 after early CB play completes CB R1 and unlocks CB R2', () => {
+      let t = start8();
+      const [m0, m1, m2, m3] = t.winners.matchesForRound(1);
+      t = t.withMatchResult(m0.id, 1);
+      t = t.withMatchResult(m1.id, 1);
+      t = t.withMatchResult(t.consolation.matchesForRound(1)[0].id, 1);
+
+      t = t.withMatchResult(m2.id, 1);
+      t = t.withMatchResult(m3.id, 1);
+      expect(t.consolation.matchesForRound(1)).toHaveLength(2);
+
+      const pending = t.consolation.matchesForRound(1).find(m => m.winner === undefined)!;
+      t = t.withMatchResult(pending.id, 1);
+      const cb2 = t.consolation.matchesForRound(2);
+      expect(cb2).toHaveLength(1);
+      const cb1Winners = t.consolation.matchesForRound(1).map(m => m.winner === 1 ? m.team1.id : m.team2.id);
+      expect(new Set([cb2[0].team1.id, cb2[0].team2.id])).toEqual(new Set(cb1Winners));
+    });
+
+    it('8 teams: CB tree keeps its final 2-round shape while WB R1 is partially decided', () => {
+      let t = start8();
+      const [m0, m1, m2] = t.winners.matchesForRound(1);
+
+      t = t.withMatchResult(m0.id, 1);
+      let tree = t.consolation.computeTree();
+      expect(tree).toHaveLength(2);
+      expect(tree[0].every(n => n.type === 'tbd')).toBe(true);
+
+      t = t.withMatchResult(m1.id, 1);
+      t = t.withMatchResult(m2.id, 1);
+      tree = t.consolation.computeTree();
+      expect(tree).toHaveLength(2);
+      expect(tree[0][0].type).toBe('match');
+      expect(tree[0][1].type).toBe('tbd');
     });
   });
 
@@ -535,6 +648,89 @@ describe('EliminationTournament', () => {
       const t = playFullTournament(EliminationTournament.create().start(teams, 4));
       expect(t.isComplete()).toBe(true);
       expect(t.calculateStandings()).toHaveLength(10);
+    });
+  });
+
+  describe('withMatchResult — changing a decided result', () => {
+    function playWBRound1(teams: TournamentTeam[]) {
+      let t = EliminationTournament.create().start(teams, 4);
+      const [m0, m1] = t.winners.matchesForRound(1);
+      t = t.withMatchResult(m0.id, 1);
+      t = t.withMatchResult(m1.id, 1);
+      return { t, m0, m1 };
+    }
+
+    it('regenerates the next WB round with the corrected winner', () => {
+      const { t: played, m0 } = playWBRound1(createTournamentTeams(['A', 'B', 'C', 'D']));
+      expect(played.winners.matchesForRound(2)).toHaveLength(1);
+
+      const t = played.withMatchResult(m0.id, 2);
+
+      const r2 = t.winners.matchesForRound(2);
+      expect(r2).toHaveLength(1);
+      const r2TeamIds = [r2[0].team1.id, r2[0].team2.id];
+      expect(r2TeamIds).toContain(m0.team2.id);
+      expect(r2TeamIds).not.toContain(m0.team1.id);
+    });
+
+    it('moves the new loser into the consolation bracket', () => {
+      const { t: played, m0 } = playWBRound1(createTournamentTeams(['A', 'B', 'C', 'D']));
+
+      const t = played.withMatchResult(m0.id, 2);
+
+      const cb1 = t.consolation.matchesForRound(1);
+      expect(cb1).toHaveLength(1);
+      const cbTeamIds = [cb1[0].team1.id, cb1[0].team2.id];
+      expect(cbTeamIds).toContain(m0.team1.id);
+      expect(cbTeamIds).not.toContain(m0.team2.id);
+    });
+
+    it('discards dependent results so the tournament is no longer complete', () => {
+      const { t: played, m0 } = playWBRound1(createTournamentTeams(['A', 'B', 'C', 'D']));
+      let t = playAllCBRounds(playWBRound(played, 2));
+      expect(t.isComplete()).toBe(true);
+
+      t = t.withMatchResult(m0.id, 2);
+
+      expect(t.isComplete()).toBe(false);
+      expect(t.phase()).toBe('active');
+      expect(t.winners.matchesForRound(2)[0].winner).toBeUndefined();
+      expect(t.calculateStandings()).toHaveLength(4);
+    });
+
+    it('re-confirming the same winner keeps downstream matches intact', () => {
+      const { t: played, m0 } = playWBRound1(createTournamentTeams(['A', 'B', 'C', 'D']));
+      let t = playWBRound(played, 2);
+      const r2Before = t.winners.matchesForRound(2)[0];
+
+      t = t.withMatchResult(m0.id, 1);
+
+      const r2After = t.winners.matchesForRound(2)[0];
+      expect(r2After.id).toBe(r2Before.id);
+      expect(r2After.winner).toBe(r2Before.winner);
+    });
+
+    it('changing a WB R2 result in an 8-team bracket keeps CB R1 results but resets later rounds', () => {
+      const teams = createTournamentTeams(['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']);
+      let t = EliminationTournament.create().start(teams, 4);
+      t = playWBRound(t, 1);
+      t = playAllCBRounds(t);
+      const cb1Before = t.consolation.matchesForRound(1);
+      t = playWBRound(t, 2);
+      const [sf0] = t.winners.matchesForRound(2);
+      t = playWBRound(t, 3);
+      expect(t.winners.matchesForRound(3)).toHaveLength(1);
+
+      t = t.withMatchResult(sf0.id, 2);
+
+      const cb1After = t.consolation.matchesForRound(1);
+      expect(cb1After.map(m => m.winner)).toEqual(cb1Before.map(m => m.winner));
+      const final = t.winners.matchesForRound(3);
+      expect(final).toHaveLength(1);
+      const finalTeamIds = [final[0].team1.id, final[0].team2.id];
+      expect(finalTeamIds).toContain(sf0.team2.id);
+      expect(finalTeamIds).not.toContain(sf0.team1.id);
+      expect(final[0].winner).toBeUndefined();
     });
   });
 

--- a/tests/tournament/bracketTree.test.ts
+++ b/tests/tournament/bracketTree.test.ts
@@ -175,6 +175,25 @@ describe('ConsolationBracket.computeTree', () => {
     });
   });
 
+  describe('pending seed slots (WB R1 losers not yet known)', () => {
+    it('renders pending slots as tbd, never as bye-advance', () => {
+      const [L1, L3] = createTournamentTeams(['L1', 'L3']);
+      const tree = new ConsolationBracket([L1, null, L3, null], [], 8).computeTree();
+      expect(tree).toHaveLength(2);
+      expect(tree[0]).toHaveLength(2);
+      expect(tree[0][0].type).toBe('tbd');
+      expect(tree[0][1].type).toBe('tbd');
+      expect(tree[1][0].type).toBe('tbd');
+    });
+
+    it('a pending slot paired with a bye is tbd until the loser is known', () => {
+      const [L1, L2] = createTournamentTeams(['L1', 'L2']);
+      const tree = new ConsolationBracket([L1, L2, null], [], 16).computeTree();
+      expect(tree[0][0].type).toBe('tbd');
+      expect(tree[0][1].type).toBe('tbd');
+    });
+  });
+
   describe('2 CB seeds (from 4-team WB R1, bracketSize=4)', () => {
     const seeds = createTournamentTeams(['L1', 'L2']);
 

--- a/tests/utils/StorageManager.test.ts
+++ b/tests/utils/StorageManager.test.ts
@@ -144,6 +144,14 @@ describe('StorageManager', () => {
       expect(loaded).toEqual({});
     });
 
+    it('should round-trip roundsPlayed through the compact format', async () => {
+      await storageManager.saveEngine({ ...mockEngineState, roundsPlayed: 7 });
+
+      const loaded = await storageManager.loadEngine();
+
+      expect(loaded.roundsPlayed).toBe(7);
+    });
+
     it('should handle localStorage save errors gracefully', async () => {
       vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
         throw new Error('Storage quota exceeded');

--- a/tests/utils/ocrEngine.test.ts
+++ b/tests/utils/ocrEngine.test.ts
@@ -8,7 +8,7 @@ import { describe, expect, it } from 'vitest';
 import { recognizePlayerNames } from '../../src/utils/ocrEngine';
 
 const workerPath = (() => {
-  const root = path.resolve(__dirname, '../../../..');
+  const root = path.resolve(__dirname, '../..');
   return path.join(root, 'node_modules', 'tesseract.js', 'src', 'worker-script', 'node', 'index.js');
 })();
 

--- a/tests/utils/rotateCourtTeams.test.ts
+++ b/tests/utils/rotateCourtTeams.test.ts
@@ -79,6 +79,20 @@ describe('rotateCourtTeams', () => {
       expect(rotated.winner).toBeUndefined();
     });
 
+    it('clears score on rotation', () => {
+      const court: Court = {
+        courtNumber: 1,
+        players: [A, B, C, D],
+        teams: { team1: [A, B], team2: [C, D] },
+        winner: 1,
+        score: { team1: 21, team2: 15 },
+      };
+
+      const rotated = rotateCourtTeams(court);
+
+      expect(rotated.score).toBeUndefined();
+    });
+
     it('preserves court number and players array', () => {
       const court: Court = {
         courtNumber: 3,
@@ -107,6 +121,20 @@ describe('rotateCourtTeams', () => {
   });
 
   describe('singles (2 players)', () => {
+    it('clears score on rotation', () => {
+      const court: Court = {
+        courtNumber: 1,
+        players: [A, B],
+        teams: { team1: [A], team2: [B] },
+        winner: 1,
+        score: { team1: 21, team2: 12 },
+      };
+
+      const rotated = rotateCourtTeams(court);
+
+      expect(rotated.score).toBeUndefined();
+    });
+
     it('swaps team1 and team2', () => {
       const court: Court = {
         courtNumber: 1,


### PR DESCRIPTION
#  Summary

  - Elimination bracket — Winners and consolation matches are now seeded per-slot, as soon as both feeder slots are decided, instead of waiting for the whole round. The consolation bracket renders  from tournament start with TBD slots.
  - State & persistence — numberOfCourts, assignments, and lastGeneratedAt now live in AppStateProvider behind a single load/save path; CourtAssignmentTracker round-delta state is static so it's shared across engine instances.
  - OCR — The progress logger is passed through createWorker at creation time, and the image file input mounts regardless of the extracted-players state.
  - Cleanup — Resolve the score once in ScoreInputModal, drop a stale cast in CourtAssignments, fix analytics court-number label precedence, and stop auto-expanding the current round-robin round.
